### PR TITLE
Automatically remove "Missing mice in:" headers pasted into map helper.

### DIFF
--- a/src/searchByMouse.php
+++ b/src/searchByMouse.php
@@ -21,6 +21,7 @@ function main() {
 function clean($mouse) {
     $mouse = trim($mouse);
     $mouse = preg_replace("/\ mouse$/i", "", $mouse);
+    $mouse = preg_replace("/(\s(.+?) found (these|this) (mouse|mice):\(\d+?\))|(Missing (mouse|mice) in .+?\(\d+?\))/i", "", $mouse);
     return $mouse;
 }
 


### PR DESCRIPTION
I tend to accidentally copy the "Missing Mice in <location>: (<number>) or "So and so found these mice:" when copying over my map list manually. 

This adds a second regex replacement to strip those out. 