### PR TITLE
setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "composer" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    reviewers: 
+      - "DevJackSmith"
+      - "AardWolf"
+      - "tehhowch"
+    


### PR DESCRIPTION
Added the correct ecosystem to the .github/dependabot.yml file
Now, dependabot should check for updates once a week and automatically assign the expected reviewers to the PRs it opens.
resolves #186