### PR TITLE
Fix bug when rejection log file is missing or empty

### DIFF
--- a/src/rejection_intake.php
+++ b/src/rejection_intake.php
@@ -36,6 +36,8 @@ function recordRejectionsInFile($limit = 250) {
         if (count($data) >= $limit) {
             $data = array_slice($data, 0, $limit - 1, true); // Limit to last limit - 1 entries
         }
+    } else {
+        $data = [];
     }
 
     $data[$timestamp] = [


### PR DESCRIPTION
`$data` remains unconverted to array if rejection log file is missing or empty and causes exception on line 43. This commit fixes it.