### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    reviewers: 
-      - "DevJackSmith"
-      - "AardWolf"
-      - "tehhowch"


### PR DESCRIPTION
removed "reviewers" because it is being deprecated.